### PR TITLE
Bind to 0.0.0.0 instead of localhost

### DIFF
--- a/lib/statik.js
+++ b/lib/statik.js
@@ -59,7 +59,7 @@ function statik(opts) {
   var static = serveStatic(options.root, options);
   app.use(static);
 
-  var server = app.listen(options.port, options.expose ? undefined : 'localhost');
+  var server = app.listen(options.port, options.expose ? undefined : '0.0.0.0');
   console.log(`🤓 Served by statikk: ${url}`);
   return {app, server, port: options.port, url};
 };


### PR DESCRIPTION
This still allows you to access the local site with localhost, but it also exposes itself to other computers on the network (ie I can go to `http://192.168.1.58:8000/` from a mobile device on the same network)

FWIW this is what `python3 -m http.server` does