### PR TITLE
suppress log and wait for server listening in lib

### DIFF
--- a/bin/statikk
+++ b/bin/statikk
@@ -40,5 +40,6 @@ if (options.argv.remain[0] !== undefined)
 	options.root = path.resolve(options.argv.remain[0]);
 
 var statik = require('../index');
-var server = statik(options);
-const port = server.port;
+statik(options).then((server) => {
+	console.log(`🤓 Served by statikk: ${server.url}`);
+});

--- a/lib/statik.js
+++ b/lib/statik.js
@@ -60,8 +60,9 @@ function statik(opts) {
   app.use(static);
 
   var server = app.listen(options.port, options.expose ? undefined : 'localhost');
-  console.log(`🤓 Served by statikk: ${url}`);
-  return {app, server, port: options.port, url};
+  return new Promise(resolve => {
+    server.once('listening', resolve({app, server, port: options.port, url}));
+  });
 };
 
 module.exports = statik;


### PR DESCRIPTION
didn't want this log 👀 

<img width="734" alt="image" src="https://user-images.githubusercontent.com/4071474/221392054-1bb3542f-f1bc-4efc-a2de-8e5254e70898.png">


also seemed like the library should return a promise that resolves only when the server is ready