### PR TITLE
fix binding default of localhost without --expose

### DIFF
--- a/bin/statikk
+++ b/bin/statikk
@@ -51,5 +51,5 @@ statik(opts).then(({url, options}) => {
 	const reset = '\x1b[0m';
 	const boldWhite = '\x1b[1m\x1b[37m';
 	const dimWhite = '\x1b[2m\x1b[37m';
-	console.log(boldWhite, `🤓 ${url}`, reset, 'statikk serving up:', `${dimWhite}${formattedPath}`, reset);
+	console.log(boldWhite, `🤓 ${url}`, reset, `statikk serving ${opts.expose ? 'up' : 'locally'}:`, `${dimWhite}${formattedPath}`, reset);
 });

--- a/lib/statik.js
+++ b/lib/statik.js
@@ -67,7 +67,7 @@ function statik(opts) {
 
   app.use(serveStatic(options.root, options));
 
-  var server = app.listen(options.port, options.expose ? undefined : '0.0.0.0');
+  var server = app.listen(options.port, options.expose ? undefined : 'localhost');
   return new Promise((resolve, reject) => {
     server.once('listening', resolve({app, server, options, url}));
     server.once('error', reject);


### PR DESCRIPTION
in https://github.com/paulirish/statikk/commit/b14e2c639588f2bb6a510162e1a96f8f33db7edb I switching the binding.. I am not 100% why.   but it was wrong.

But.. if you want the server to be accessible outside localhost... use the `--expose` option.

Slightly tweaked the stdout to remind the user/myself.

Edit: shipped this in v2.2.2